### PR TITLE
Renamed VideoController

### DIFF
--- a/YoutubeJam.Api/Controllers/VideosController.cs
+++ b/YoutubeJam.Api/Controllers/VideosController.cs
@@ -6,7 +6,7 @@ namespace YoutubeJam.Api.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class VidoesController : ControllerBase
+    public class VideosController : ControllerBase
     {
         
         /// <summary>


### PR DESCRIPTION
Had a minor spelling Error in the VideoController API. Been fixed